### PR TITLE
Updated SDK to be interoparable with other Atsign SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ All of our software is open with intent. We welcome contributions - we want pull
 
 ## Steps to Beta
 - [ ] Notifications using the `monitor` verb
-- [ ] Interoperability with other SDKs
+- [x] Interoperability with other SDKs
 
 ## Future goals
 - [ ] `no_std` implementation

--- a/src/at_chops/at_chops.rs
+++ b/src/at_chops/at_chops.rs
@@ -82,9 +82,7 @@ pub fn decrypt_data_with_shared_symmetric_key(encoded_symmetric_key: &str, data:
     let iv: [u8; 16] = [0x00; 16];
     let mut cypher = construct_aes_key(&decoded_symmetric_key, &iv);
     let decoded_data = base64_decode(&data);
-    warn!("Encrypted data: {:x?}", decoded_data);
     let decrypted_data = decrypt_data_with_aes_key(&mut cypher, &decoded_data);
-    warn!("Decrypted data: {:x?}", decrypted_data);
     String::from_utf8(decrypted_data).expect("Unable to convert to UTF-8")
 }
 

--- a/src/at_chops/at_chops.rs
+++ b/src/at_chops/at_chops.rs
@@ -1,4 +1,4 @@
-use log::warn;
+use log::{info, warn};
 
 use super::utils::{
     base64_decode, base64_encode, construct_aes_key, construct_rsa_private_key,
@@ -70,6 +70,7 @@ pub fn encrypt_data_with_shared_symmetric_key(encoded_symmetric_key: &str, data:
     let decoded_symmetric_key = base64_decode(&encoded_symmetric_key);
     let iv: [u8; 16] = [0x00; 16];
     let mut cypher = construct_aes_key(&decoded_symmetric_key, &iv);
+    // TODO: Need to pad this for Pkcs7
     let encrypted_data = encrypt_data_with_aes_key(&mut cypher, &data.as_bytes());
     base64_encode(&encrypted_data)
 }
@@ -77,12 +78,13 @@ pub fn encrypt_data_with_shared_symmetric_key(encoded_symmetric_key: &str, data:
 /// Decrypt data with an encoded AES symm key.
 pub fn decrypt_data_with_shared_symmetric_key(encoded_symmetric_key: &str, data: &str) -> String {
     let decoded_symmetric_key = base64_decode(&encoded_symmetric_key);
+    info!("Symmetric key: {:x?}", decoded_symmetric_key);
     let iv: [u8; 16] = [0x00; 16];
     let mut cypher = construct_aes_key(&decoded_symmetric_key, &iv);
     let decoded_data = base64_decode(&data);
-    warn!("Encrypted data: {:?}", decoded_data);
+    warn!("Encrypted data: {:x?}", decoded_data);
     let decrypted_data = decrypt_data_with_aes_key(&mut cypher, &decoded_data);
-    warn!("Decrypted data: {:?}", decrypted_data);
+    warn!("Decrypted data: {:x?}", decrypted_data);
     String::from_utf8(decrypted_data).expect("Unable to convert to UTF-8")
 }
 

--- a/src/at_chops/at_chops.rs
+++ b/src/at_chops/at_chops.rs
@@ -70,7 +70,6 @@ pub fn encrypt_data_with_shared_symmetric_key(encoded_symmetric_key: &str, data:
     let decoded_symmetric_key = base64_decode(&encoded_symmetric_key);
     let iv: [u8; 16] = [0x00; 16];
     let mut cypher = construct_aes_key(&decoded_symmetric_key, &iv);
-    // TODO: Need to pad this for Pkcs7
     let encrypted_data = encrypt_data_with_aes_key(&mut cypher, &data.as_bytes());
     base64_encode(&encrypted_data)
 }
@@ -78,7 +77,6 @@ pub fn encrypt_data_with_shared_symmetric_key(encoded_symmetric_key: &str, data:
 /// Decrypt data with an encoded AES symm key.
 pub fn decrypt_data_with_shared_symmetric_key(encoded_symmetric_key: &str, data: &str) -> String {
     let decoded_symmetric_key = base64_decode(&encoded_symmetric_key);
-    info!("Symmetric key: {:x?}", decoded_symmetric_key);
     let iv: [u8; 16] = [0x00; 16];
     let mut cypher = construct_aes_key(&decoded_symmetric_key, &iv);
     let decoded_data = base64_decode(&data);

--- a/src/at_chops/at_chops.rs
+++ b/src/at_chops/at_chops.rs
@@ -1,3 +1,5 @@
+use log::warn;
+
 use super::utils::{
     base64_decode, base64_encode, construct_aes_key, construct_rsa_private_key,
     construct_rsa_public_key, create_new_aes_key, decrypt_data_with_aes_key,
@@ -77,8 +79,11 @@ pub fn decrypt_data_with_shared_symmetric_key(encoded_symmetric_key: &str, data:
     let decoded_symmetric_key = base64_decode(&encoded_symmetric_key);
     let iv: [u8; 16] = [0x00; 16];
     let mut cypher = construct_aes_key(&decoded_symmetric_key, &iv);
-    let encrypted_data = decrypt_data_with_aes_key(&mut cypher, &base64_decode(&data));
-    String::from_utf8(encrypted_data).expect("Unable to convert to UTF-8")
+    let decoded_data = base64_decode(&data);
+    warn!("Encrypted data: {:?}", decoded_data);
+    let decrypted_data = decrypt_data_with_aes_key(&mut cypher, &decoded_data);
+    warn!("Decrypted data: {:?}", decrypted_data);
+    String::from_utf8(decrypted_data).expect("Unable to convert to UTF-8")
 }
 
 #[cfg(test)]

--- a/src/at_chops/at_chops.rs
+++ b/src/at_chops/at_chops.rs
@@ -49,7 +49,6 @@ pub fn create_new_shared_symmetric_key() -> String {
 pub fn decrypt_symmetric_key(encrypted_symmetric_key: &str, decrypted_private_key: &str) -> String {
     let decoded_private_key = base64_decode(&decrypted_private_key);
     let rsa_private_key = construct_rsa_private_key(&decoded_private_key);
-    // NOTE: Probs need to do the same as decrypt_symmetric_key_2
     let decoded_symmetric_key = base64_decode(&encrypted_symmetric_key);
     let decrypted_symmetric_key =
         decrypt_symm_key_with_private_key(&rsa_private_key, &decoded_symmetric_key);
@@ -60,11 +59,7 @@ pub fn decrypt_symmetric_key(encrypted_symmetric_key: &str, decrypted_private_ke
 pub fn encrypt_data_with_public_key(encoded_public_key: &str, data: &str) -> String {
     let decoded_public_key = base64_decode(&encoded_public_key);
     let rsa_public_key = construct_rsa_public_key(&decoded_public_key);
-
-    // NOTE: Not sure if I need to decode the data or pass it in as bytes.
-
-    let encrypted_data = encrypt_with_public_key(&rsa_public_key, &base64_decode(&data));
-    // let encrypted_data = encrypt_with_public_key(&rsa_public_key, &data.as_bytes());
+    let encrypted_data = encrypt_with_public_key(&rsa_public_key, &data.as_bytes());
     encrypted_data
 }
 
@@ -82,10 +77,7 @@ pub fn decrypt_data_with_shared_symmetric_key(encoded_symmetric_key: &str, data:
     let decoded_symmetric_key = base64_decode(&encoded_symmetric_key);
     let iv: [u8; 16] = [0x00; 16];
     let mut cypher = construct_aes_key(&decoded_symmetric_key, &iv);
-    // let mut encrypted_data = decrypt_data_with_aes_key(&mut cypher, &data.as_bytes());
     let encrypted_data = decrypt_data_with_aes_key(&mut cypher, &base64_decode(&data));
-
-    // base64_encode(&encrypted_data)
     String::from_utf8(encrypted_data).expect("Unable to convert to UTF-8")
 }
 

--- a/src/at_chops/utils.rs
+++ b/src/at_chops/utils.rs
@@ -82,7 +82,7 @@ pub fn decrypt_symm_key_with_private_key(private_key: &RsaPrivateKey, symm_key: 
     let decrypted_symmetric_key = private_key
         .decrypt(Pkcs1v15Encrypt, symm_key)
         .expect("Failed to decrypt symmetric key");
-    base64_encode(&decrypted_symmetric_key)
+    String::from_utf8(decrypted_symmetric_key).expect("Failed to convert decrypted key to string")
 }
 
 /// Encrypt some data using an AES key.
@@ -100,6 +100,7 @@ pub fn decrypt_data_with_aes_key(
     aes_key: &mut Box<dyn SynchronousStreamCipher>,
     data: &[u8],
 ) -> Vec<u8> {
+    // TODO: This probably requires some padding wrangling
     let mut output: Vec<u8> = vec![0; data.len()];
     aes_key.process(&data, &mut output);
     output

--- a/src/at_chops/utils.rs
+++ b/src/at_chops/utils.rs
@@ -100,9 +100,10 @@ pub fn decrypt_data_with_aes_key(
     aes_key: &mut Box<dyn SynchronousStreamCipher>,
     data: &[u8],
 ) -> Vec<u8> {
-    // TODO: This probably requires some padding wrangling
     let mut output: Vec<u8> = vec![0; data.len()];
     aes_key.process(&data, &mut output);
+    let last = output.last().unwrap();
+    output.truncate(output.len() - usize::from(*last));
     output
 }
 


### PR DESCRIPTION
**- What I did**
- Removed padding created by PKCS#7 encryption when decrypting data
- Added required padding when encrypting data

**- How to verify it**
- Send data from the Rust SDK (e.g. using the example found in the README) and then read it from a different client (e.g. Python SDK) and confirm there are no errors and data is correctly decrypted
- Read data from the Rust SDK (e.g. using the example) that was sent from a different client (e.g. Python) and confirm the data is correctly read and decrypted

**- Description for the changelog**
Updated SDK to be interoparable with other Atsign SDKs by using PKCS#7 padding for AES encryption/decryption